### PR TITLE
Update fetch-ssl-pinning-config

### DIFF
--- a/bin/fetch-ssl-pinning-config
+++ b/bin/fetch-ssl-pinning-config
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const fetchSslPinningConfig = require('../lib/fetchSslPinningConfig');
+const URL = require('url').URL;
 
 const promises = process.argv
   .slice(2)


### PR DESCRIPTION
I always get the error message "URL is not defined".
"const URL = require('url').URL;" fixed it