### PR TITLE
Only Check for domains that exist in the config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,12 @@ function createVerificator(config: Config) {
   });
 
   return (request: CertificateVerifyProcRequest, callback: (verificationResult: number) => void) => {
+    const domainExistsInConfig = config.some((fp) => fp.domain === request.hostname);
+    if(!domainExistsInConfig) {
+      callback(-3);
+      return;
+    }
+    
     const fingerprints: Array<string> = []; 
     for (let cert = request.certificate; cert && cert !== cert.issuerCert; cert = cert.issuerCert) {
       fingerprints.push(cert.fingerprint);


### PR DESCRIPTION
I only want to check the fingerprints of domains that I know - the domains of the app. I don't want to add fingerprinting for domains like CDNs.